### PR TITLE
Release / 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
+docs
 
 ## Obj-C/Swift specific
 *.hmap

--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -6,6 +6,5 @@ github_file_prefix: https://github.com/polydice/ICInputAccessory/blob/develop
 xcodebuild_arguments: [-scheme, ICInputAccessory-iOS]
 module: ICInputAccessory
 module_version: 1.1.0
-swift_version: 2.2
 output: docs/output
-theme: apple
+theme: fullwidth

--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -5,6 +5,6 @@ github_url: https://github.com/polydice/ICInputAccessory
 github_file_prefix: https://github.com/polydice/ICInputAccessory/blob/develop
 xcodebuild_arguments: [-scheme, ICInputAccessory-iOS]
 module: ICInputAccessory
-module_version: 1.1.0
+module_version: 1.2.0
 output: docs/output
 theme: fullwidth

--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -1,0 +1,11 @@
+clean: true
+author: polydice
+author_url: https://github.com/polydice
+github_url: https://github.com/polydice/ICInputAccessory
+github_file_prefix: https://github.com/polydice/ICInputAccessory/blob/develop
+xcodebuild_arguments: [-scheme, ICInputAccessory-iOS]
+module: ICInputAccessory
+module_version: 1.1.0
+swift_version: 2.2
+output: docs/output
+theme: apple

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       script: bundle exec rake ci:build[latest]
     - env: BUILD=carthage
       script: make carthage
+      after_script:
+        - make documentation
 cache:
   bundler: true
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.0
+
+#### Changes
+
+* Swift 2.3
+
 ## v1.1.0
 
 #### Changes

--- a/Example/Example/Info.plist
+++ b/Example/Example/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Example/ICInputAccessoryUITests/Info.plist
+++ b/Example/ICInputAccessoryUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 ruby "2.3.1"
 
 gem "cocoapods", "~> 1.0.0"
-gem "jazzy", git: "https://github.com/realm/jazzy.git", ref: "8b88e33"
+gem "jazzy", "~> 0.7.0"
 gem "pry"
 gem "rake"
 gem "xcpretty"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "http://rubygems.org"
 ruby "2.3.1"
 
 gem "cocoapods", "~> 1.0.0"
+gem "jazzy", git: "https://github.com/realm/jazzy.git", ref: "8b88e33"
 gem "pry"
 gem "rake"
 gem "xcpretty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,7 @@
-GIT
-  remote: https://github.com/realm/jazzy.git
-  revision: 8b88e33d9c6d2d3d0f2958963e4d709304e6b293
-  ref: 8b88e33
-  specs:
-    jazzy (0.7.0)
-      cocoapods (~> 1.0)
-      mustache (~> 0.99)
-      open4
-      redcarpet (~> 3.2)
-      rouge (~> 1.5)
-      sass (~> 3.4)
-      sqlite3 (~> 1.3)
-      xcinvoke (~> 0.2.1)
-
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (5.0.0)
+    activesupport (5.0.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -43,8 +28,8 @@ GEM
       activesupport (>= 4.0.2)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
-    cocoapods-deintegrate (1.0.0)
-    cocoapods-downloader (1.1.0)
+    cocoapods-deintegrate (1.0.1)
+    cocoapods-downloader (1.1.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
@@ -60,6 +45,15 @@ GEM
     fourflusher (0.3.2)
     fuzzy_match (2.0.4)
     i18n (0.7.0)
+    jazzy (0.7.2)
+      cocoapods (~> 1.0)
+      mustache (~> 0.99)
+      open4
+      redcarpet (~> 3.2)
+      rouge (~> 1.5)
+      sass (~> 3.4)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.2.1)
     liferaft (0.0.4)
     method_source (0.8.2)
     minitest (5.9.0)
@@ -83,7 +77,7 @@ GEM
       thread_safe (~> 0.1)
     xcinvoke (0.2.1)
       liferaft (~> 0.0.4)
-    xcodeproj (1.2.0)
+    xcodeproj (1.3.1)
       activesupport (>= 3)
       claide (>= 1.0.0, < 2.0)
       colored (~> 1.2)
@@ -95,7 +89,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.0.0)
-  jazzy!
+  jazzy (~> 0.7.0)
   pry
   rake
   xcpretty

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/realm/jazzy.git
+  revision: 8b88e33d9c6d2d3d0f2958963e4d709304e6b293
+  ref: 8b88e33
+  specs:
+    jazzy (0.7.0)
+      cocoapods (~> 1.0)
+      mustache (~> 0.99)
+      open4
+      redcarpet (~> 3.2)
+      rouge (~> 1.5)
+      sass (~> 3.4)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.2.1)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -45,21 +60,29 @@ GEM
     fourflusher (0.3.2)
     fuzzy_match (2.0.4)
     i18n (0.7.0)
+    liferaft (0.0.4)
     method_source (0.8.2)
     minitest (5.9.0)
     molinillo (0.4.5)
+    mustache (0.99.8)
     nap (1.1.0)
     netrc (0.7.8)
+    open4 (1.3.4)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rake (11.2.2)
+    redcarpet (3.3.4)
     rouge (1.11.1)
+    sass (3.4.22)
     slop (3.6.0)
+    sqlite3 (1.3.11)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    xcinvoke (0.2.1)
+      liferaft (~> 0.0.4)
     xcodeproj (1.2.0)
       activesupport (>= 3)
       claide (>= 1.0.0, < 2.0)
@@ -72,6 +95,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.0.0)
+  jazzy!
   pry
   rake
   xcpretty

--- a/ICInputAccessory.podspec
+++ b/ICInputAccessory.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "ICInputAccessory"
-  s.version       = "1.1.0"
+  s.version       = "1.2.0"
   s.summary       = "A customized token text field used in the iCook app."
   s.description   = <<-DESC
                      ICKeyboardDismissTextField:

--- a/ICInputAccessory/Info.plist
+++ b/ICInputAccessory/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 install: brew-install bundle-install pod-install
 
 brew-install:
+	brew update
 	brew tap homebrew/bundle
 	brew bundle
 
@@ -16,3 +17,6 @@ setup: brew-install
 
 carthage:
 	set -o pipefail && carthage build --no-skip-current --verbose | xcpretty
+
+documentation:
+	bundle exec jazzy --config .jazzy.yml

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - ICInputAccessory/KeyboardDismissTextField (1.1.0)
-  - ICInputAccessory/TokenField (1.1.0)
+  - ICInputAccessory/KeyboardDismissTextField (1.2.0)
+  - ICInputAccessory/TokenField (1.2.0)
 
 DEPENDENCIES:
   - ICInputAccessory/KeyboardDismissTextField (from `./`)
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  ICInputAccessory: fa69a534ae8811866fa9d63a6b3ecf07bfced685
+  ICInputAccessory: 75941a41865c7fab675c9252fd3101b79a7aea62
 
 PODFILE CHECKSUM: 41c0babd8a8e47d9dc4741ac44d6bb453b85139d
 

--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 Customized text fields used in the [iCook app](https://itunes.apple.com/app/id554065086).
 Try <https://testflight.icook.tw>.
 
-[![Build Status](https://travis-ci.org/polydice/ICInputAccessory.svg?branch=develop)](https://travis-ci.org/polydice/ICInputAccessory)
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ICInputAccessory.svg)](https://img.shields.io/cocoapods/v/ICInputAccessory.svg)
-[![Platform](https://img.shields.io/cocoapods/p/ICInputAccessory.svg?style=flat)](https://cocoapods.org/pods/ICInputAccessory)
+[![Build Status](https://travis-ci.org/polydice/ICInputAccessory.svg)](https://travis-ci.org/polydice/ICInputAccessory)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg)](https://github.com/Carthage/Carthage)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ICInputAccessory.svg)](https://cocoapods.org/pods/ICInputAccessory)
+![Platform](https://img.shields.io/cocoapods/p/ICInputAccessory.svg)
+[![Docs](https://img.shields.io/cocoapods/metrics/doc-percent/ICInputAccessory.svg)](http://cocoadocs.org/docsets/ICInputAccessory/)
 ![Swift 2.3](https://img.shields.io/badge/Swift-2.3-orange.svg)
 
 ### ICKeyboardDismissTextField
 
-* An input accessory view with a button to dismiss keyboard.
+* A text field that has a button to dismiss keyboard on the input accessory view.
 
 ### ICTokenField
 
@@ -26,9 +27,10 @@ Try <https://testflight.icook.tw>.
 
 ICInputAccessory | iOS  | Xcode | Swift
 ---------------- | :--: | :---: | -----
-`~> v1.0.0`      | 8.0+ | 7.2   | ![Swift 2.1.1](https://img.shields.io/badge/Swift-2.1.1-orange.svg)
-`~> v1.1.0`      | 8.0+ | 7.3   | ![Swift 2.2](https://img.shields.io/badge/Swift-2.2-orange.svg)
-`develop` branch | 8.0+ | 8.0   | ![Swift 2.3](https://img.shields.io/badge/Swift-2.3-orange.svg)
+`~> 1.0.0`       | 8.0+ | 7.2   | ![Swift 2.1.1](https://img.shields.io/badge/Swift-2.1.1-orange.svg)
+`~> 1.1.0`       | 8.0+ | 7.3   | ![Swift 2.2](https://img.shields.io/badge/Swift-2.2-orange.svg)
+`~> 1.2.0`       | 8.0+ | 8.0   | ![Swift 2.3](https://img.shields.io/badge/Swift-2.3-orange.svg)
+`feature/swift-3`| 8.0+ | 8.0   | ![Swift 3.0](https://img.shields.io/badge/Swift-3.0-orange.svg)
 
 ## Installation
 

--- a/Source/KeyboardDismissTextField/ICKeyboardDismissAccessoryView.swift
+++ b/Source/KeyboardDismissTextField/ICKeyboardDismissAccessoryView.swift
@@ -26,16 +26,18 @@
 
 import UIKit
 
+/// A customized keyboard accessory view with a dismiss button.
 @IBDesignable
 public class ICKeyboardDismissAccessoryView: UIView {
 
   /// The background color of the button to dismiss keyboard.
-  @IBInspectable var buttonColor: UIColor = Constants.ButtonColor {
+  @IBInspectable public var buttonColor: UIColor = Constants.ButtonColor {
     didSet {
       dismissButton.backgroundColor = buttonColor
     }
   }
 
+  /// The button to dismiss keyboard.
   public private(set) lazy var dismissButton: UIButton = {
     let _button = UIButton()
     let resources = NSBundle(forClass: self.dynamicType)
@@ -57,11 +59,13 @@ public class ICKeyboardDismissAccessoryView: UIView {
 
   // MARK: - Initialization
 
+  /// Initializes and returns a newly allocated view object with the specified frame rectangle.
   public override init(frame: CGRect) {
     super.init(frame: frame)
     setUpSubviews()
   }
 
+  /// Returns an object initialized from data in a given unarchiver.
   public required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
     setUpSubviews()

--- a/Source/KeyboardDismissTextField/ICKeyboardDismissTextField.swift
+++ b/Source/KeyboardDismissTextField/ICKeyboardDismissTextField.swift
@@ -26,9 +26,11 @@
 
 import UIKit
 
+/// A text field that has a button to dismiss keyboard on the input accessory view.
 @IBDesignable
 public class ICKeyboardDismissTextField: UITextField {
 
+  /// The custom input accessory view with a button to dismiss keyboard.
   @IBOutlet public var keyboardAccessoryView: ICKeyboardDismissAccessoryView! {
     didSet {
       if UI_USER_INTERFACE_IDIOM() != .Phone { return }
@@ -39,11 +41,13 @@ public class ICKeyboardDismissTextField: UITextField {
 
   // MARK: - Initialization
 
+  /// Initializes and returns a newly allocated view object with the specified frame rectangle.
   public override init(frame: CGRect) {
     super.init(frame: frame)
     setUpAccessoryView()
   }
 
+  /// Returns an object initialized from data in a given unarchiver.
   public required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
     setUpAccessoryView()

--- a/Source/TokenField/ICTokenField.swift
+++ b/Source/TokenField/ICTokenField.swift
@@ -41,15 +41,13 @@ import UIKit
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-
-
+/// A text field that groups input texts with delimiters.
 @IBDesignable
 public class ICTokenField: UIView, UITextFieldDelegate, ICBackspaceTextFieldDelegate {
 
   // MARK: - Public Properties
 
-  /// The receiver’s delegate.
+  /// The receiver's delegate.
   public weak var delegate: ICTokenFieldDelegate?
 
   /// Characters that completes a new token, defaults are whitespace and commas.
@@ -117,7 +115,7 @@ public class ICTokenField: UIView, UITextFieldDelegate, ICBackspaceTextFieldDele
     }
   }
 
-  /// Customized attributes for tokens in the normal state, e.g. NSFontAttributeName and NSForegroundColorAttributeName.
+  /// Customized attributes for tokens in the normal state, e.g. `NSFontAttributeName` and `NSForegroundColorAttributeName`.
   public var normalTokenAttributes: [String: NSObject]? {
     didSet {
       tokens.forEach { $0.normalTextAttributes = normalTokenAttributes ?? [:] }
@@ -211,11 +209,13 @@ public class ICTokenField: UIView, UITextFieldDelegate, ICBackspaceTextFieldDele
 
   // MARK: - Initialization
 
+  /// Initializes and returns a newly allocated view object with the specified frame rectangle.
   public override init(frame: CGRect) {
     super.init(frame: frame)
     setUpSubviews()
   }
 
+  /// Returns an object initialized from data in a given unarchiver.
   public required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
     setUpSubviews()
@@ -365,9 +365,7 @@ public class ICTokenField: UIView, UITextFieldDelegate, ICBackspaceTextFieldDele
 
   // MARK: - Private Methods
 
-  /**
-  Returns true if any highlighted token is found and removed, otherwise false.
-  */
+  /// Returns true if any highlighted token is found and removed, otherwise false.
   private func removeHighlightedToken() -> Bool {
     for (index, token) in tokens.enumerate() {
       if token.highlighted {


### PR DESCRIPTION
It's about time to release `1.2.0` before moving on to Swift 3. 

Comments are also updated to improve the generated [docs](http://cocoadocs.org/docsets/ICInputAccessory/):

``` sh
make documentation && open docs/output/index.html
```
