### PR TITLE
Fix Example Layout in iOS 11

### DIFF
--- a/Example/CustomizedTokenField.swift
+++ b/Example/CustomizedTokenField.swift
@@ -39,6 +39,10 @@ class CustomizedTokenField: ICTokenField {
     applyCustomizedStyle()
   }
 
+  override var intrinsicContentSize: CGSize {
+    return UILayoutFittingExpandedSize
+  }
+
 }
 
 

--- a/Example/CustomizedTokenViewController.swift
+++ b/Example/CustomizedTokenViewController.swift
@@ -56,7 +56,20 @@ class CustomizedTokenViewController: UIViewController, ICTokenFieldDelegate {
     cancelBarButton.tintColor = UIColor.white
     navigationItem.rightBarButtonItem = cancelBarButton
 
-    navigationItem.titleView = tokenField
+    navigationItem.titleView = {
+      if #available(iOS 11, *) {
+        tokenField.translatesAutoresizingMaskIntoConstraints = false
+        let views = ["field": tokenField]
+        let metrics = ["padding": 7]
+        let containerView = UIView()
+        containerView.addSubview(tokenField)
+        containerView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[field]-padding-|", options: [], metrics: metrics, views: views))
+        containerView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-padding-[field]-padding-|", options: [], metrics: metrics, views: views))
+        return containerView
+      } else {
+        return tokenField
+      }
+    }()
     tokenField.delegate = self
   }
 

--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -54,6 +54,7 @@ class ExampleViewController: UITableViewController {
 
   override func loadView() {
     super.loadView()
+    tableView.rowHeight = 44
     tableView.register(ExampleCell.self, forCellReuseIdentifier: String(describing: ExampleCell.self))
     tableView.tableFooterView = flipButton
     tableView.tableFooterView?.isUserInteractionEnabled = true


### PR DESCRIPTION
**KeyboardDismissTextField**: Specify the `rowHeight` for the text field in table view cells.

**TokenField**: Manually set the margins for the token field in the navigation bar.

![artboard](https://user-images.githubusercontent.com/2032500/31583204-113a5fa4-b15c-11e7-9b1e-33f331fe2a1d.png)
