### PR TITLE
Fix tokenField(_:didChangeInputText:) with Delete Key

### DIFF
--- a/Example/CustomizedTokenField.swift
+++ b/Example/CustomizedTokenField.swift
@@ -39,6 +39,10 @@ class CustomizedTokenField: ICTokenField {
     applyCustomizedStyle()
   }
 
+  override var intrinsicContentSize: CGSize {
+    return UILayoutFittingExpandedSize
+  }
+
 }
 
 

--- a/Example/CustomizedTokenViewController.swift
+++ b/Example/CustomizedTokenViewController.swift
@@ -56,7 +56,20 @@ class CustomizedTokenViewController: UIViewController, ICTokenFieldDelegate {
     cancelBarButton.tintColor = UIColor.white
     navigationItem.rightBarButtonItem = cancelBarButton
 
-    navigationItem.titleView = tokenField
+    navigationItem.titleView = {
+      if #available(iOS 11, *) {
+        tokenField.translatesAutoresizingMaskIntoConstraints = false
+        let views = ["field": tokenField]
+        let metrics = ["padding": 7]
+        let containerView = UIView()
+        containerView.addSubview(tokenField)
+        containerView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[field]-padding-|", options: [], metrics: metrics, views: views))
+        containerView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-padding-[field]-padding-|", options: [], metrics: metrics, views: views))
+        return containerView
+      } else {
+        return tokenField
+      }
+    }()
     tokenField.delegate = self
   }
 

--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -54,6 +54,7 @@ class ExampleViewController: UITableViewController {
 
   override func loadView() {
     super.loadView()
+    tableView.rowHeight = 44
     tableView.register(ExampleCell.self, forCellReuseIdentifier: String(describing: ExampleCell.self))
     tableView.tableFooterView = flipButton
     tableView.tableFooterView?.isUserInteractionEnabled = true

--- a/Source/TokenField/ICTokenField.swift
+++ b/Source/TokenField/ICTokenField.swift
@@ -328,19 +328,25 @@ open class ICTokenField: UIView, UITextFieldDelegate, ICBackspaceTextFieldDelega
   // MARK: - ICBackspaceTextFieldDelegate
 
   @nonobjc func textFieldShouldDelete(_ textField: ICBackspaceTextField) -> Bool {
-    if tokens.isEmpty {
-      return true
-    }
-
     if !textField.showsCursor {
       _ = removeHighlightedToken()
       return true
     }
 
-    if let text = textField.text, text.isEmpty {
+    guard let text = textField.text else {
+      return true
+    }
+
+    if text.isEmpty {
       textField.showsCursor = false
       tokens.last?.isHighlighted = true
+    } else {
+      // textField(_:shouldChangeCharactersIn:replacementString:) is skipped when the delete key is pressed.
+      // Notify the delegate of the changed input text manually.
+      let index = text.index(text.endIndex, offsetBy: -1)
+      delegate?.tokenField?(self, didChangeInputText: text.substring(to: index))
     }
+
     return true
   }
 


### PR DESCRIPTION
Regarding the issue mentioned in #15, `textField(_:shouldChangeCharactersIn:replacementString:)` is skipped when the delete key is pressed.

The delegate could be notified of the changed input text from `textFieldShouldDelete(_:)`. Tested with CJK input methods, it seems okay for normal use cases.