### PR TITLE
Option Picker Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## `develop`
+
+* Drop Class Name Prefixes
+* Add an easy to use `OptionPickerControl` that displays a `UIPickerView` with given options
+
 ## v1.5.0
 
 * Swift 4.0

--- a/Example/Language.swift
+++ b/Example/Language.swift
@@ -51,7 +51,7 @@ enum Language: String, OptionDescriptive {
     return rawValue.capitalized
   }
 
-  static var optionalText: String {
+  static var titleForOptionalValue: String {
     return "(Optional)"
   }
 

--- a/Example/Language.swift
+++ b/Example/Language.swift
@@ -1,0 +1,58 @@
+//
+//  Language.swift
+//  Example
+//
+//  Created by Ben on 20/01/2018.
+//  Copyright © 2018 bcylin.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import ICInputAccessory
+
+enum Language: String, OptionDescriptive {
+
+  case english
+  case french
+  case german
+  case japanese
+  case mandarin
+  case spanish
+
+  static var availableLanguages: [Language] = [
+    .english,
+    .french,
+    .german,
+    .japanese,
+    .mandarin,
+    .spanish
+  ]
+
+  // MARK: - OptionDescriptive
+
+  var title: String {
+    return rawValue.capitalized
+  }
+
+  static var optionalText: String {
+    return "(Optional)"
+  }
+
+}

--- a/ICInputAccessory.podspec
+++ b/ICInputAccessory.podspec
@@ -23,11 +23,15 @@ Pod::Spec.new do |s|
   s.source        = { git: "https://github.com/polydice/ICInputAccessory.git", tag: "v#{s.version}" }
   s.requires_arc  = true
 
-  s.default_subspecs = "KeyboardDismissTextField", "TokenField"
+  s.default_subspecs = "KeyboardDismissTextField", "OptionPickerControl", "TokenField"
 
   s.subspec "KeyboardDismissTextField" do |sp|
     sp.source_files  = "Source/KeyboardDismissTextField/*.swift"
     sp.resources     = "Source/KeyboardDismissTextField/*.xcassets"
+  end
+
+  s.subspec "OptionPickerControl" do |sp|
+    sp.source_files  = "Source/OptionPickerControl/*.swift"
   end
 
   s.subspec "TokenField" do |sp|

--- a/ICInputAccessory.xcodeproj/project.pbxproj
+++ b/ICInputAccessory.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		B52ADB1920132F0C00D96B87 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ADB1720132F0C00D96B87 /* Option.swift */; };
 		B52ADB1A20132F0C00D96B87 /* OptionPickerControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ADB1820132F0C00D96B87 /* OptionPickerControl.swift */; };
 		B52ADB1C201332E400D96B87 /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ADB1B201332E400D96B87 /* Language.swift */; };
+		B52ADB1F201485B800D96B87 /* OptionPickerControlUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ADB1D201485A700D96B87 /* OptionPickerControlUITests.swift */; };
 		B533768B1F4436D000230739 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533768A1F4436D000230739 /* AppDelegate.swift */; };
 		B53376921F4436D000230739 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B53376911F4436D000230739 /* Assets.xcassets */; };
 		B53376951F4436D000230739 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B53376931F4436D000230739 /* LaunchScreen.storyboard */; };
@@ -76,6 +77,7 @@
 		B52ADB1720132F0C00D96B87 /* Option.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Option.swift; path = Source/OptionPickerControl/Option.swift; sourceTree = SOURCE_ROOT; };
 		B52ADB1820132F0C00D96B87 /* OptionPickerControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OptionPickerControl.swift; path = Source/OptionPickerControl/OptionPickerControl.swift; sourceTree = SOURCE_ROOT; };
 		B52ADB1B201332E400D96B87 /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Language.swift; sourceTree = "<group>"; };
+		B52ADB1D201485A700D96B87 /* OptionPickerControlUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OptionPickerControlUITests.swift; path = ICInputAccessoryUITests/OptionPickerControlUITests.swift; sourceTree = SOURCE_ROOT; };
 		B53376881F4436D000230739 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B533768A1F4436D000230739 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B53376911F4436D000230739 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 			children = (
 				B53376A11F4436D000230739 /* Info.plist */,
 				B53376A91F4437D900230739 /* KeyboardDismissTextFieldUITests.swift */,
+				B52ADB1D201485A700D96B87 /* OptionPickerControlUITests.swift */,
 				B53376AA1F4437D900230739 /* TokenFieldUITests.swift */,
 			);
 			name = ICInputAccessoryUITests;
@@ -437,6 +440,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B53376AB1F4437D900230739 /* KeyboardDismissTextFieldUITests.swift in Sources */,
+				B52ADB1F201485B800D96B87 /* OptionPickerControlUITests.swift in Sources */,
 				B53376AC1F4437D900230739 /* TokenFieldUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ICInputAccessory.xcodeproj/project.pbxproj
+++ b/ICInputAccessory.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		B528196F1C9035BE007D01D5 /* TokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528196B1C9035BE007D01D5 /* TokenField.swift */; };
 		B52ADB1920132F0C00D96B87 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ADB1720132F0C00D96B87 /* Option.swift */; };
 		B52ADB1A20132F0C00D96B87 /* OptionPickerControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ADB1820132F0C00D96B87 /* OptionPickerControl.swift */; };
+		B52ADB1C201332E400D96B87 /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ADB1B201332E400D96B87 /* Language.swift */; };
 		B533768B1F4436D000230739 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533768A1F4436D000230739 /* AppDelegate.swift */; };
 		B53376921F4436D000230739 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B53376911F4436D000230739 /* Assets.xcassets */; };
 		B53376951F4436D000230739 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B53376931F4436D000230739 /* LaunchScreen.storyboard */; };
@@ -74,6 +75,7 @@
 		B528196B1C9035BE007D01D5 /* TokenField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TokenField.swift; path = Source/TokenField/TokenField.swift; sourceTree = SOURCE_ROOT; };
 		B52ADB1720132F0C00D96B87 /* Option.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Option.swift; path = Source/OptionPickerControl/Option.swift; sourceTree = SOURCE_ROOT; };
 		B52ADB1820132F0C00D96B87 /* OptionPickerControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OptionPickerControl.swift; path = Source/OptionPickerControl/OptionPickerControl.swift; sourceTree = SOURCE_ROOT; };
+		B52ADB1B201332E400D96B87 /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Language.swift; sourceTree = "<group>"; };
 		B53376881F4436D000230739 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B533768A1F4436D000230739 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B53376911F4436D000230739 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 				B53376AF1F44387000230739 /* ExampleCell.swift */,
 				B53376B01F44387000230739 /* ExampleViewController.swift */,
 				B53376961F4436D000230739 /* Info.plist */,
+				B52ADB1B201332E400D96B87 /* Language.swift */,
 				B53376931F4436D000230739 /* LaunchScreen.storyboard */,
 				B53376B11F44387000230739 /* Main.storyboard */,
 				B53376B21F44387000230739 /* StoryboardViewController.swift */,
@@ -424,6 +427,7 @@
 				B53376B41F44387000230739 /* CustomizedTokenViewController.swift in Sources */,
 				B53376B51F44387000230739 /* ExampleCell.swift in Sources */,
 				B53376B61F44387000230739 /* ExampleViewController.swift in Sources */,
+				B52ADB1C201332E400D96B87 /* Language.swift in Sources */,
 				B53376B81F44387000230739 /* StoryboardViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ICInputAccessory.xcodeproj/project.pbxproj
+++ b/ICInputAccessory.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		B528196D1C9035BE007D01D5 /* InsetLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52819691C9035BE007D01D5 /* InsetLabel.swift */; };
 		B528196E1C9035BE007D01D5 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528196A1C9035BE007D01D5 /* Token.swift */; };
 		B528196F1C9035BE007D01D5 /* TokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528196B1C9035BE007D01D5 /* TokenField.swift */; };
+		B52ADB1920132F0C00D96B87 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ADB1720132F0C00D96B87 /* Option.swift */; };
+		B52ADB1A20132F0C00D96B87 /* OptionPickerControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52ADB1820132F0C00D96B87 /* OptionPickerControl.swift */; };
 		B533768B1F4436D000230739 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533768A1F4436D000230739 /* AppDelegate.swift */; };
 		B53376921F4436D000230739 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B53376911F4436D000230739 /* Assets.xcassets */; };
 		B53376951F4436D000230739 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B53376931F4436D000230739 /* LaunchScreen.storyboard */; };
@@ -70,6 +72,8 @@
 		B52819691C9035BE007D01D5 /* InsetLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InsetLabel.swift; path = Source/TokenField/InsetLabel.swift; sourceTree = SOURCE_ROOT; };
 		B528196A1C9035BE007D01D5 /* Token.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Token.swift; path = Source/TokenField/Token.swift; sourceTree = SOURCE_ROOT; };
 		B528196B1C9035BE007D01D5 /* TokenField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TokenField.swift; path = Source/TokenField/TokenField.swift; sourceTree = SOURCE_ROOT; };
+		B52ADB1720132F0C00D96B87 /* Option.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Option.swift; path = Source/OptionPickerControl/Option.swift; sourceTree = SOURCE_ROOT; };
+		B52ADB1820132F0C00D96B87 /* OptionPickerControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OptionPickerControl.swift; path = Source/OptionPickerControl/OptionPickerControl.swift; sourceTree = SOURCE_ROOT; };
 		B53376881F4436D000230739 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B533768A1F4436D000230739 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B53376911F4436D000230739 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -148,6 +152,15 @@
 			name = TokenField;
 			sourceTree = "<group>";
 		};
+		B52ADB1220132EEF00D96B87 /* OptionPickerControl */ = {
+			isa = PBXGroup;
+			children = (
+				B52ADB1720132F0C00D96B87 /* Option.swift */,
+				B52ADB1820132F0C00D96B87 /* OptionPickerControl.swift */,
+			);
+			name = OptionPickerControl;
+			sourceTree = "<group>";
+		};
 		B53376891F4436D000230739 /* Example */ = {
 			isa = PBXGroup;
 			children = (
@@ -202,6 +215,7 @@
 			isa = PBXGroup;
 			children = (
 				B52819671C90358C007D01D5 /* KeyboardDismissAccessory */,
+				B52ADB1220132EEF00D96B87 /* OptionPickerControl */,
 				B52819701C9035C3007D01D5 /* TokenField */,
 				B56BC42D1C89A7EA00C20AD6 /* ICInputAccessory.h */,
 				B548C5AC1C8D69A5009D5AEE /* Images.xcassets */,
@@ -431,6 +445,8 @@
 				B528196D1C9035BE007D01D5 /* InsetLabel.swift in Sources */,
 				B56BC4361C89A8D800C20AD6 /* KeyboardDismissAccessoryView.swift in Sources */,
 				B548C5EE1C8EB9E2009D5AEE /* KeyboardDismissTextField.swift in Sources */,
+				B52ADB1920132F0C00D96B87 /* Option.swift in Sources */,
+				B52ADB1A20132F0C00D96B87 /* OptionPickerControl.swift in Sources */,
 				B528196E1C9035BE007D01D5 /* Token.swift in Sources */,
 				B528196F1C9035BE007D01D5 /* TokenField.swift in Sources */,
 			);

--- a/ICInputAccessoryUITests/OptionPickerControlUITests.swift
+++ b/ICInputAccessoryUITests/OptionPickerControlUITests.swift
@@ -1,0 +1,64 @@
+//
+//  OptionPickerControlUITests.swift
+//  ICInputAccessoryUITests
+//
+//  Created by Ben on 21/01/2018.
+//  Copyright © 2018 bcylin.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import XCTest
+
+final class OptionPickerControlUITests: XCTestCase {
+
+  private lazy var app = XCUIApplication()
+
+  override func setUp() {
+    super.setUp()
+    continueAfterFailure = false
+    XCUIApplication().launch()
+  }
+
+  func testOptionSelection() {
+    app.tables.staticTexts["(Optional)"].tap()
+    let picker = app.pickerWheels.element
+
+    picker.adjust(toPickerWheelValue: "English")
+    XCTAssert(app.tables.staticTexts["English"].exists)
+
+    picker.adjust(toPickerWheelValue: "French")
+    XCTAssert(app.tables.staticTexts["French"].exists)
+
+    picker.adjust(toPickerWheelValue: "German")
+    XCTAssert(app.tables.staticTexts["German"].exists)
+
+    picker.adjust(toPickerWheelValue: "Japanese")
+    XCTAssert(app.tables.staticTexts["Japanese"].exists)
+
+    picker.adjust(toPickerWheelValue: "Mandarin")
+    XCTAssert(app.tables.staticTexts["Mandarin"].exists)
+
+    picker.adjust(toPickerWheelValue: "Spanish")
+    XCTAssert(app.tables.staticTexts["Spanish"].exists)
+
+    app.toolbars.buttons["Done"].tap()
+  }
+
+}

--- a/Source/OptionPickerControl/Option.swift
+++ b/Source/OptionPickerControl/Option.swift
@@ -1,0 +1,69 @@
+//
+//  Option.swift
+//  Flashcards
+//
+//  Created by Ben on 22/11/2017.
+//  Copyright © 2017 bcylin.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+public protocol OptionDescriptive: Equatable {
+  var title: String { get }
+  static var optionalText: String { get }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+public struct Option<T: OptionDescriptive>: Equatable {
+
+  // MARK: - Initialization
+
+  public static func optional() -> Option<T> {
+    return Option<T>()
+  }
+
+  public init(_ value: T) {
+    self.value = value
+  }
+
+  // MARK: - Properties
+
+  public var title: String {
+    return value?.title ?? T.optionalText
+  }
+
+  public let value: T?
+
+  // MARK: - Private
+
+  private init() {
+    self.value = nil
+  }
+
+  // MARK: - Equatable
+
+  public static func == (lhs: Option<T>, rhs: Option<T>) -> Bool {
+    return lhs.value == rhs.value
+  }
+
+}

--- a/Source/OptionPickerControl/Option.swift
+++ b/Source/OptionPickerControl/Option.swift
@@ -1,6 +1,6 @@
 //
 //  Option.swift
-//  Flashcards
+//  ICInputAccessory
 //
 //  Created by Ben on 22/11/2017.
 //  Copyright © 2017 bcylin.
@@ -26,32 +26,38 @@
 
 import Foundation
 
+/// The protocol defines the required variables to be displayed in a `UIPickerView` via `OptionPickerControl`.
 public protocol OptionDescriptive: Equatable {
+  /// The text for the row in the `UIPickerView`.
   var title: String { get }
-  static var optionalText: String { get }
+  /// The text for a placeholder row when the picker selection is optional.
+  static var titleForOptionalValue: String { get }
 }
 
-////////////////////////////////////////////////////////////////////////////////
 
-
+/// An option struct that carries the `OptionDescriptive`
 public struct Option<T: OptionDescriptive>: Equatable {
 
   // MARK: - Initialization
 
+  /// Returns an option that displays the optional value of an `OptionDescriptive` type.
   public static func optional() -> Option<T> {
     return Option<T>()
   }
 
+  /// Returns an initialized option with an instance of an `OptionDescriptive` type.
   public init(_ value: T) {
     self.value = value
   }
 
   // MARK: - Properties
 
+  /// Conformance to `OptionDescriptive`.
   public var title: String {
-    return value?.title ?? T.optionalText
+    return value?.title ?? T.titleForOptionalValue
   }
 
+  /// The `OptionDescriptive` value of the option. Returns `nil` when it's the `optional` placeholder.
   public let value: T?
 
   // MARK: - Private
@@ -62,6 +68,7 @@ public struct Option<T: OptionDescriptive>: Equatable {
 
   // MARK: - Equatable
 
+  /// Returns true when two options' values are equal.
   public static func == (lhs: Option<T>, rhs: Option<T>) -> Bool {
     return lhs.value == rhs.value
   }

--- a/Source/OptionPickerControl/OptionPickerControl.swift
+++ b/Source/OptionPickerControl/OptionPickerControl.swift
@@ -1,0 +1,123 @@
+//
+//  OptionPickerControl.swift
+//  Flashcards
+//
+//  Created by Ben on 27/11/2017.
+//  Copyright © 2017 bcylin.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import UIKit
+
+open class OptionPickerControl<T: OptionDescriptive>: UIControl,
+  UIPickerViewDataSource,
+  UIPickerViewDelegate {
+
+  // MARK: - Initialization
+
+  public init() {
+    super.init(frame: .zero)
+    addSubview(hiddenTextField)
+  }
+
+  required public init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) is not supported")
+  }
+
+  // MARK: - Properties
+
+  public var options: [Option<T>] = [Option<T>.optional()]
+  public var selectedOption: Option<T> = Option<T>.optional() {
+    didSet {
+      if hiddenTextField.isFirstResponder {
+        sendActions(for: .valueChanged)
+      } else if let index = options.index(of: selectedOption) {
+        picker.selectRow(index, inComponent: 0, animated: false)
+      }
+    }
+  }
+
+  // MARK: - Lazy Instantiation
+
+  private lazy var doneBarButton: UIBarButtonItem =
+    UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissPicker(_:)))
+
+  private lazy var pickerToolbar: UIToolbar = {
+    let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44))
+    toolbar.items = [
+      UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+      self.doneBarButton
+    ]
+    return toolbar
+  }()
+
+  private lazy var picker: UIPickerView = {
+    let picker = UIPickerView()
+    picker.dataSource = self
+    picker.delegate = self
+    return picker
+  }()
+
+  private lazy var hiddenTextField: UITextField = {
+    let textField = UITextField()
+    textField.inputAccessoryView = self.pickerToolbar
+    textField.inputView = self.picker
+    return textField
+  }()
+
+  // MARK: - UIResponder
+
+  @discardableResult
+  override open func becomeFirstResponder() -> Bool {
+    return super.becomeFirstResponder() || hiddenTextField.becomeFirstResponder()
+  }
+
+  @discardableResult
+  override open func resignFirstResponder() -> Bool {
+    return hiddenTextField.resignFirstResponder()
+  }
+
+  // MARK: - UIPickerViewDataSource
+
+  open func numberOfComponents(in pickerView: UIPickerView) -> Int {
+    return 1
+  }
+
+  open func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    return options.count
+  }
+
+  // MARK: - UIPickerViewDelegate
+
+  open func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+    return options[row].title
+  }
+
+  open func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+    selectedOption = options[row]
+  }
+
+  // MARK: - IBActions
+
+  @objc private func dismissPicker(_ sender: Any) {
+    resignFirstResponder()
+  }
+
+}

--- a/Source/OptionPickerControl/OptionPickerControl.swift
+++ b/Source/OptionPickerControl/OptionPickerControl.swift
@@ -1,6 +1,6 @@
 //
 //  OptionPickerControl.swift
-//  Flashcards
+//  ICInputAccessory
 //
 //  Created by Ben on 27/11/2017.
 //  Copyright © 2017 bcylin.
@@ -26,24 +26,28 @@
 
 import UIKit
 
-open class OptionPickerControl<T: OptionDescriptive>: UIControl,
-  UIPickerViewDataSource,
-  UIPickerViewDelegate {
+/// A `UIControl` that displays a `UIPickerView` and notifies changed selection and via `UIControlEvents` `.valueChanged`.
+open class OptionPickerControl<T: OptionDescriptive>: UIControl, UIPickerViewDataSource, UIPickerViewDelegate {
 
   // MARK: - Initialization
 
+  /// Returns an initialized `OptionPickerControl`.
   public init() {
     super.init(frame: .zero)
     addSubview(hiddenTextField)
   }
 
+  /// Not supported. `OptionPickerControl` is not compatible with storyboards.
   required public init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) is not supported")
   }
 
   // MARK: - Properties
 
+  /// Options that shows in the `UIPickerView`.
   public var options: [Option<T>] = [Option<T>.optional()]
+
+  /// The currently selected item in the options.
   public var selectedOption: Option<T> = Option<T>.optional() {
     didSet {
       if hiddenTextField.isFirstResponder {
@@ -53,6 +57,14 @@ open class OptionPickerControl<T: OptionDescriptive>: UIControl,
       }
     }
   }
+
+  /// A reference to the displayed `UIPickerView` for customization.
+  public private(set) lazy var picker: UIPickerView = {
+    let picker = UIPickerView()
+    picker.dataSource = self
+    picker.delegate = self
+    return picker
+  }()
 
   // MARK: - Lazy Instantiation
 
@@ -66,13 +78,6 @@ open class OptionPickerControl<T: OptionDescriptive>: UIControl,
       self.doneBarButton
     ]
     return toolbar
-  }()
-
-  private lazy var picker: UIPickerView = {
-    let picker = UIPickerView()
-    picker.dataSource = self
-    picker.delegate = self
-    return picker
   }()
 
   private lazy var hiddenTextField: UITextField = {
@@ -96,6 +101,7 @@ open class OptionPickerControl<T: OptionDescriptive>: UIControl,
 
   // MARK: - UIPickerViewDataSource
 
+  /// Currently `OptionPickerControl` only supports one component.
   open func numberOfComponents(in pickerView: UIPickerView) -> Int {
     return 1
   }


### PR DESCRIPTION
Add an easy to use `OptionPickerControl` that displays a `UIPickerView` with given options:

An example type that conforms to `OptionDescriptive`:

```swift
extension String: OptionDescriptive {

  var title: String {
    return self
  }

  static var titleForOptionalValue: String {
    return "(optional)"
  }

}
```

Initialize `OptionPickerControl` with `CGRect.zero` and add it to the view hierarchy:

```swift
let optionPicker = OptionPickerControl<String>()
optionPicker.options = [Option<String>.optional(), Option("Option 1"), Option("Option 2")]
optionPicker.addTarget(self, action: #selector(didChangeOption(_:)), for: .valueChanged)
view.addSubview(optionPicker)
```

To show the `UIPickerView`:

```swift
optionPicker.becomeFirstResponder()
```

The specified selector `didChangeOption(_:)` will be called when the selected row in `UIPickerView` changes.