### PR TITLE
Disable JS/CSS lints from Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,11 @@
+eslint:
+  enabled: false
+jshint:
+  enabled: false
+sass-lint:
+  enabled: false
+scss:
+  enabled: false
 swift:
   enabled: true
   config_file: .swiftlint.yml


### PR DESCRIPTION
Follow up of #26, where Hound CI bots left many comments on generated assets. I thought it's easier to just disable non Swift linters.

@bcylin Could you please have a look?