### PR TITLE
Fix The Embedded Standard Library Issue

### DIFF
--- a/ICInputAccessory.xcodeproj/project.pbxproj
+++ b/ICInputAccessory.xcodeproj/project.pbxproj
@@ -571,7 +571,6 @@
 		B56BC4301C89A7EA00C20AD6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -631,7 +630,6 @@
 		B56BC4311C89A7EA00C20AD6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -684,7 +682,6 @@
 		B56BC4331C89A7EA00C20AD6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -705,7 +702,6 @@
 		B56BC4341C89A7EA00C20AD6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
This should fix #31 by removing `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` from the framework build settings.

The built framework bundle will be:

```
ICInputAccessory.framework
├── Assets.car
├── Headers
│   ├── ICInputAccessory-Swift.h
│   └── ICInputAccessory.h
├── ICInputAccessory
├── Info.plist
└── Modules
    ├── ICInputAccessory.swiftmodule
    │   ├── arm.swiftdoc
    │   ├── arm.swiftmodule
    │   ├── arm64.swiftdoc
    │   ├── arm64.swiftmodule
    │   ├── i386.swiftdoc
    │   ├── i386.swiftmodule
    │   ├── x86_64.swiftdoc
    │   └── x86_64.swiftmodule
    └── module.modulemap
```
